### PR TITLE
fix #18 use strict=False

### DIFF
--- a/src/fuzzy_json/decoder.py
+++ b/src/fuzzy_json/decoder.py
@@ -272,7 +272,7 @@ def repair_json(json_str: str) -> str:
 
 def loads(json_str: str, auto_repair: bool = False) -> dict[str, Any]:
     try:
-        return json.loads(json_str)
+        return json.loads(json_str, strict=False)
     except json.decoder.JSONDecodeError:
         if not auto_repair:
             raise
@@ -282,4 +282,4 @@ def loads(json_str: str, auto_repair: bool = False) -> dict[str, Any]:
     except Exception as e:
         raise json.decoder.JSONDecodeError(f"Failed to repair JSON: {e}", json_str, 0)
 
-    return json.loads(repaired_json)
+    return json.loads(repaired_json, strict=False)

--- a/src/fuzzy_json/tests/__snapshots__/test_decoder.ambr
+++ b/src/fuzzy_json/tests/__snapshots__/test_decoder.ambr
@@ -50,6 +50,14 @@
     "subject's": 'Introducing the Mandelic Acid and Allantoin Acne-Care Calming Ampoule',
   })
 # ---
+# name: test_repaired_json_invalid_case_special
+  dict({
+    'a': '''
+      
+  
+    ''',
+  })
+# ---
 # name: test_repaired_json_simple_case
   dict({
   })

--- a/src/fuzzy_json/tests/test_decoder.py
+++ b/src/fuzzy_json/tests/test_decoder.py
@@ -1,26 +1,21 @@
 import json
 from pathlib import Path
-from typing import Any
 
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from ..decoder import loads
-
-
-def load_repaired_json(json_str: str) -> dict[str, Any]:
-    return loads(json_str, auto_repair=True)
+from ..decoder import loads, repair_json
 
 
 def test_repaired_json_simple_case(snapshot: SnapshotAssertion) -> None:
-    assert snapshot == load_repaired_json("{}")
-    assert snapshot == load_repaired_json('{"foo": "bar"}')
-    assert snapshot == load_repaired_json('{"foo": "bar", "baz": "qux"}')
-    assert snapshot == load_repaired_json('{"foo": "bar", "baz": "qux", "quux": "corge"}')
+    assert snapshot == json.loads(repair_json("{}"))
+    assert snapshot == json.loads(repair_json('{"foo": "bar"}'))
+    assert snapshot == json.loads(repair_json('{"foo": "bar", "baz": "qux"}'))
+    assert snapshot == json.loads(repair_json('{"foo": "bar", "baz": "qux", "quux": "corge"}'))
     # add more nested objects
-    assert snapshot == load_repaired_json('{"foo": {"bar": "baz"}}')
-    assert snapshot == load_repaired_json('{"foo": {"bar": {"baz": "qux"}}}')
-    assert snapshot == load_repaired_json('{"foo": {"bar": {"baz": {"qux": "quux"}}}}')
+    assert snapshot == json.loads(repair_json('{"foo": {"bar": "baz"}}'))
+    assert snapshot == json.loads(repair_json('{"foo": {"bar": {"baz": "qux"}}}'))
+    assert snapshot == json.loads(repair_json('{"foo": {"bar": {"baz": {"qux": "quux"}}}}'))
 
 
 @pytest.mark.parametrize(
@@ -32,7 +27,7 @@ def test_repaired_json_vaild_case(snapshot: SnapshotAssertion, test_filename: Pa
     content = test_filename.read_text()
     parsed_by_std_json = json.loads(content)
 
-    parsed_by_fixed_json = load_repaired_json(content)
+    parsed_by_fixed_json = json.loads(repair_json(content))
     assert snapshot == parsed_by_fixed_json
     assert parsed_by_fixed_json == parsed_by_std_json
 
@@ -44,13 +39,13 @@ def test_repaired_json_vaild_case(snapshot: SnapshotAssertion, test_filename: Pa
 )
 def test_repaired_json_invaild_case(snapshot: SnapshotAssertion, test_filename: Path) -> None:
     content = test_filename.read_text()
-    result = load_repaired_json(content)
+    result = loads(content, auto_repair=True)
     assert snapshot == result
 
 
 def test_repaired_json_invalid_case_special(snapshot: SnapshotAssertion) -> None:
     content = '{"a": "\n"}'
-    result = load_repaired_json(content)
+    result = loads(content, auto_repair=True)
     assert snapshot == result
     assert json.loads(content, strict=False) == result
 

--- a/src/fuzzy_json/tests/test_decoder.py
+++ b/src/fuzzy_json/tests/test_decoder.py
@@ -5,11 +5,11 @@ from typing import Any
 import pytest
 from syrupy.assertion import SnapshotAssertion
 
-from ..decoder import loads, repair_json
+from ..decoder import loads
 
 
 def load_repaired_json(json_str: str) -> dict[str, Any]:
-    return json.loads(repair_json(json_str))
+    return loads(json_str, auto_repair=True)
 
 
 def test_repaired_json_simple_case(snapshot: SnapshotAssertion) -> None:
@@ -46,6 +46,13 @@ def test_repaired_json_invaild_case(snapshot: SnapshotAssertion, test_filename: 
     content = test_filename.read_text()
     result = load_repaired_json(content)
     assert snapshot == result
+
+
+def test_repaired_json_invalid_case_special(snapshot: SnapshotAssertion) -> None:
+    content = '{"a": "\n"}'
+    result = load_repaired_json(content)
+    assert snapshot == result
+    assert json.loads(content, strict=False) == result
 
 
 def test_repair_json_fail() -> None:


### PR DESCRIPTION
- fix #18 
- 使用 strict = False 解決 input 中 `\n` encode 的問題
- 這個問題不能用檔案呈現，所以另外寫了 test case

> If strict is false (True is the default), then control characters will be allowed inside strings. Control characters in this context are those with character codes in the 0–31 range, including '\t' (tab), '\n', '\r' and '\0'.

https://docs.python.org/3/library/json.html